### PR TITLE
Update AdvancedCargoOutputNode.java

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
@@ -57,7 +57,13 @@ public class AdvancedCargoOutputNode extends SlimefunItem {
 					}
 					
 					if (!BlockStorage.hasBlockInfo(b) || BlockStorage.getLocationInfo(b.getLocation(), "filter-durability") == null || BlockStorage.getLocationInfo(b.getLocation(), "filter-durability").equals("false")) {
-						menu.replaceExistingItem(16, new CustomItem(new ItemStack(Material.STONE_SWORD, (byte) 20), "&7Include Sub-IDs/Durability: &4\u2718", "", "&e> Click to toggle whether the Durability has to match"));
+						
+						ItemStack icon = new ItemStack(Material.STONE_SWORD,1);
+						Damageable dmg = (Damageable) icon.getItemMeta();
+			 			dmg.setDamage(20);
+			 			icon.setItemMeta((ItemMeta) dmg);
+
+						menu.replaceExistingItem(16, new CustomItem(icon, "&7Include Sub-IDs/Durability: &4\u2718", "", "&e> Click to toggle whether the Durability has to match"));
 						menu.addMenuClickHandler(16, (p, slot, item, action) -> {
 							BlockStorage.addBlockInfo(b, "filter-durability", "true");
 							newInstance(menu, b);
@@ -65,7 +71,11 @@ public class AdvancedCargoOutputNode extends SlimefunItem {
 						});
 					}
 					else {
-						menu.replaceExistingItem(16, new CustomItem(new ItemStack(Material.GOLDEN_SWORD, (byte) 20), "&7Include Sub-IDs/Durability: &2\u2714", "", "&e> Click to toggle whether the Durability has to match"));
+						ItemStack icon = new ItemStack(Material.GOLDEN_SWORD,1);
+						Damageable dmg = (Damageable) icon.getItemMeta();
+			 			dmg.setDamage(20);
+			 			icon.setItemMeta((ItemMeta) dmg);
+						menu.replaceExistingItem(16, new CustomItem(icon, "&7Include Sub-IDs/Durability: &2\u2714", "", "&e> Click to toggle whether the Durability has to match"));
 						menu.addMenuClickHandler(16, (p, slot, item, action) -> {
 							BlockStorage.addBlockInfo(b, "filter-durability", "false");
 							newInstance(menu, b);


### PR DESCRIPTION
Updated cargo nodes whitelist to not use deprecated methods to set damage of the Stone_Sword